### PR TITLE
Chore: RestDoc 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.2'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'org.asciidoctor.jvm.convert' version '4.0.3'
 }
 
 ext {
@@ -29,6 +30,8 @@ configurations {
 	testCompileOnly {
 		extendsFrom testAnnotationProcessor
 	}
+
+	asciidoctorExt
 
 	configureEach {
 		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
@@ -76,21 +79,49 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation "io.rest-assured:rest-assured:$restAssureVersion"
 	testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
-}
+def querydslDir = 'build/generated/querydsl' as File
+def snippetsDir = file('build/generated-snippets') as File
+def generatedDocsDir = file("build/docs/asciidoc") as File
+def outputDocsDir = file("src/main/resources/static/docs") as File
 
-def querydslDir = 'build/generated/querydsl'
+
+test {
+	useJUnitPlatform()
+	outputs.dir snippetsDir
+}
 
 sourceSets {
 	main.java.srcDirs += [ querydslDir ]
 }
 
 tasks.withType(JavaCompile) {
-	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+	options.annotationProcessorGeneratedSourcesDirectory = querydslDir
+}
+
+asciidoctor {
+	configurations 'asciidoctorExt'
+	inputs.dir snippetsDir
+	baseDirFollowsSourceFile()
+	attributes 'snippets': snippetsDir
+	dependsOn test
+}
+
+asciidoctor.doFirst {
+	project.delete(outputDocsDir)
+}
+
+tasks.register('copyDocument', Copy) {
+	dependsOn asciidoctor
+	from generatedDocsDir
+	into outputDocsDir
+}
+
+build {
+	dependsOn copyDocument
 }

--- a/src/docs/asciidoc/apis/places/add-place.adoc
+++ b/src/docs/asciidoc/apis/places/add-place.adoc
@@ -1,0 +1,15 @@
+==== POST /places
+
+여행 장소를 추가합니다.
+
+.request
+include::{snippets}/places/add-place/http-request.adoc[]
+
+.request-fields
+include::{snippets}/places/add-place/request-fields.adoc[]
+
+.response
+include::{snippets}/places/add-place/http-response.adoc[]
+
+.response-fields
+include::{snippets}/places/add-place/response-fields.adoc[]

--- a/src/docs/asciidoc/apis/places/index.adoc
+++ b/src/docs/asciidoc/apis/places/index.adoc
@@ -1,0 +1,3 @@
+=== Place APIs
+
+include::add-place.adoc[]

--- a/src/docs/asciidoc/common/introduction.adoc
+++ b/src/docs/asciidoc/common/introduction.adoc
@@ -1,0 +1,5 @@
+== 소개
+
+이 문서는 Travel Mate 의 REST API 명세를 제공합니다.
+
+* Spring REST Docs 기반으로 자동 생성됩니다.

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,13 @@
+= Soccer Hub REST API 문서
+:doctype: book
+:icons: font
+:toc: left
+:toclevels: 2
+:sectnums:
+:source-highlighter: highlightjs
+
+include::common/introduction.adoc[]
+
+== API 목록
+
+include::apis/places/index.adoc[]

--- a/src/test/java/com/ganzi/travelmate/common/config/AbstractWebMvcTest.java
+++ b/src/test/java/com/ganzi/travelmate/common/config/AbstractWebMvcTest.java
@@ -3,14 +3,28 @@ package com.ganzi.travelmate.common.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.ganzi.travelmate.common.infra.hashid.HashIdService;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@ExtendWith(RestDocumentationExtension.class)
 public class AbstractWebMvcTest {
 
-    @Autowired
     protected MockMvc mvc;
+
+    @BeforeEach
+    public void setUp(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
+        this.mvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
 
     protected final ObjectMapper objectMapper = new ObjectMapper()
             .findAndRegisterModules()

--- a/src/test/java/com/ganzi/travelmate/common/docs/RestDocsCommonFields.java
+++ b/src/test/java/com/ganzi/travelmate/common/docs/RestDocsCommonFields.java
@@ -1,0 +1,17 @@
+package com.ganzi.travelmate.common.docs;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class RestDocsCommonFields {
+
+    public static FieldDescriptor[] commonResponseFields() {
+        return new FieldDescriptor[] {
+                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                fieldWithPath("data").description("실제 응답 데이터")
+        };
+    }
+}

--- a/src/test/java/com/ganzi/travelmate/place/controller/AddPlaceControllerTest.java
+++ b/src/test/java/com/ganzi/travelmate/place/controller/AddPlaceControllerTest.java
@@ -3,6 +3,7 @@ package com.ganzi.travelmate.place.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ganzi.travelmate.common.config.AbstractWebMvcTest;
 import com.ganzi.travelmate.common.data.PlaceTestData;
+import com.ganzi.travelmate.common.docs.RestDocsCommonFields;
 import com.ganzi.travelmate.place.adaptor.in.web.AddPlaceController;
 import com.ganzi.travelmate.place.application.command.AddPlaceCommand;
 import com.ganzi.travelmate.place.application.port.in.AddPlaceUseCase;
@@ -12,11 +13,14 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -48,12 +52,40 @@ public class AddPlaceControllerTest extends AbstractWebMvcTest {
         given(addPlaceUseCase.addPlace(any(AddPlaceCommand.class)))
                 .willReturn(place);
 
-        mvc.perform(post("/v1/places")
-                        .with(csrf())
+        mvc.perform(
+                post("/v1/places")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(addPlaceCommand)))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.data").exists());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andDo(document("places/add-place",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("장소 이름 (1~20자)"),
+                                fieldWithPath("description").type(JsonFieldType.STRING).optional().description("장소 주소"),
+                                fieldWithPath("state").type(JsonFieldType.STRING).description("주/도 (1~20자"),
+                                fieldWithPath("city").type(JsonFieldType.STRING).description("시/군/구(1~50자)"),
+                                fieldWithPath("street").type(JsonFieldType.STRING).description("도로명 (1~100자)"),
+                                fieldWithPath("detailAddress").type(JsonFieldType.STRING).optional().description("상세 주소"),
+                                fieldWithPath("postalCode").type(JsonFieldType.STRING).description("우편번호 (1~10자)"),
+                                fieldWithPath("latitude").type(JsonFieldType.NUMBER).optional().description("위도"),
+                                fieldWithPath("longitude").type(JsonFieldType.NUMBER).optional().description("경도")
+                        ),
+                        responseFields(
+                                RestDocsCommonFields.commonResponseFields()
+                        ).andWithPrefix("data.",
+                                fieldWithPath("id").description("장소 ID"),
+                                fieldWithPath("name").description("장소 이름"),
+                                fieldWithPath("description").description("장소 설명"),
+                                fieldWithPath("address.state").description("주/도"),
+                                fieldWithPath("address.city").description("시/군/구"),
+                                fieldWithPath("address.street").description("도로명"),
+                                fieldWithPath("address.detailAddress").description("상세 주소"),
+                                fieldWithPath("address.postalCode").description("우편번호"),
+                                fieldWithPath("address.latitude").description("위도"),
+                                fieldWithPath("address.longitude").description("경도"))
+                ));
     }
 
 }


### PR DESCRIPTION
## 🧾 개요
RestDoc 구성 및 add-place 문서 작성

---

## ✅ 작업 내용
- [x] restdoc 플러그인 및 태스크 구성
- [x] restdoc 공통 응답 필드 정의
- [x] add-place 문서 작성

---

## 🔍 테스트 방법 (선택)
- asciidoctor 또는 copyDocument 태스크 실행

---

## 🏷️ 관련 태그 (선택)
`문서`, `테스트`
