### PR TITLE
Chore: build 태스크 의존성 수정 및 docs/* 접근 권한 허용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,3 @@ tasks.register('copyDocument', Copy) {
 	from generatedDocsDir
 	into outputDocsDir
 }
-
-build {
-	dependsOn copyDocument
-}

--- a/src/main/java/com/ganzi/travelmate/auth/SecurityConfiguration.java
+++ b/src/main/java/com/ganzi/travelmate/auth/SecurityConfiguration.java
@@ -65,7 +65,7 @@ public class SecurityConfiguration {
                                 )
                 )
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/h2-console/**", "/v1/auth/**", "/oauth2/authorization/*").permitAll()
+                        .requestMatchers("/h2-console/**", "/v1/auth/**", "/oauth2/authorization/*", "/docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtAuthProvider), UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 🧾 개요
gradle build 태스크의 copyDocument 의존성을 제거하고 docs/* 경로의 접근 권한을 허용하도록 수정

---

## ✅ 작업 내용
- [x] build 태스크의 copyDocument 의존성을 제거
- [x] Spring Security filterChain의 docs/* 경로의 접근 권한을 허용

---

## 🏷️ 관련 태그 (선택)
`기능`, `문서`
